### PR TITLE
Memory leak in process spawning

### DIFF
--- a/src/gen_tcpd.erl
+++ b/src/gen_tcpd.erl
@@ -361,6 +361,7 @@ init_acceptor(Parent, Callback, CState, Socket, SSLTimeout) ->
 	try link(Parent)
 		catch error:noproc -> exit(normal)
 	end,
+	put('$ancestors', tl(get('$ancestors'))),
 	accept(Parent, Callback, CState, Socket, SSLTimeout).
 
 accept(Parent, Callback, CState, Socket, SSLTimeout) ->


### PR DESCRIPTION
Since proc_lib is used to start the process a list of all the ancestors are kept in the process dict. This patch prunes the ancestor dict so that each new process does not add a new element to that list and this not leaking memory any more.
